### PR TITLE
Add cts/mts file support

### DIFF
--- a/scripts/pglite-types.ts
+++ b/scripts/pglite-types.ts
@@ -101,7 +101,7 @@ async function processFile(filePath: string): Promise<QueryCall[]> {
 
 // Recursively find all TypeScript files in the directory using a promise-based glob
 function getAllTSFiles(dirPath: string): Promise<string[]> {
-  return glob(`${dirPath}/**/*.{ts,tsx}`);
+  return glob(`${dirPath}/**/*.{ts,tsx,mts,cts}`);
 }
 
 // Main function to scan codebase for query method calls


### PR DESCRIPTION
Some typescript files use `cts` and `mts` as the file extension and the glob currently misses them.